### PR TITLE
Allow to define note duration on creation

### DIFF
--- a/src/renderer/components/MusicTrack/Music.js
+++ b/src/renderer/components/MusicTrack/Music.js
@@ -1,6 +1,13 @@
 export const NoteTooSmallException = () => {
 }
 
+/* Examples:
+clip(10.3, 1) => 10
+clip(12, 5) => 10
+clip(15.01, 2.5) => 15.0
+*/
+const clip = (value, increment) => Math.floor(value / increment) * increment
+
 export class Note {
   constructor (startTime, duration, pitch) {
     this.startTime = startTime
@@ -33,10 +40,10 @@ export class NoteCanvasAdapter {
 
   clip (renderContext, box) {
     return {
-      x: Math.floor(box.x / renderContext.percentPerQuarter) * renderContext.percentPerQuarter,
-      y: Math.floor(box.y / renderContext.percentPerInterval) * renderContext.percentPerInterval,
-      width: Math.floor(box.width / renderContext.percentPerQuarter) * renderContext.percentPerQuarter,
-      height: box.height
+      x: clip(box.x, renderContext.percentPerQuarter),
+      y: clip(box.y, renderContext.percentPerInterval),
+      width: clip(box.width, renderContext.percentPerQuarter),
+      height: clip(box.height, renderContext.percentPerInterval)
     }
   }
 }

--- a/src/renderer/components/MusicTrack/Music.js
+++ b/src/renderer/components/MusicTrack/Music.js
@@ -1,3 +1,6 @@
+export const NoteTooSmallException = () => {
+}
+
 export class Note {
   constructor (startTime, duration, pitch) {
     this.startTime = startTime
@@ -17,11 +20,24 @@ export class NoteCanvasAdapter {
   }
 
   toNote (renderContext, box) {
+    const width = Math.floor(box.width / renderContext.percentPerQuarter)
+    if (!width) {
+      throw new NoteTooSmallException()
+    }
     return new Note(
       Math.floor(box.x / renderContext.percentPerQuarter),
-      box.width / renderContext.percentPerQuarter,
+      width,
       Math.floor(box.y / renderContext.percentPerInterval)
     )
+  }
+
+  clip (renderContext, box) {
+    return {
+      x: Math.floor(box.x / renderContext.percentPerQuarter) * renderContext.percentPerQuarter,
+      y: Math.floor(box.y / renderContext.percentPerInterval) * renderContext.percentPerInterval,
+      width: Math.floor(box.width / renderContext.percentPerQuarter) * renderContext.percentPerQuarter,
+      height: box.height
+    }
   }
 }
 

--- a/src/renderer/components/MusicTrack/MusicTrack.vue
+++ b/src/renderer/components/MusicTrack/MusicTrack.vue
@@ -1,19 +1,32 @@
 <template>
-  <div class="wrapper">
-    <note-canvas @canvas-click="onClickCanvas">
-      <note-box
-        v-for="box in noteBoxes"
-        :x="box.x"
-        :y="box.y"
-        :width="box.width"
-        :height="box.height"
-        :color="'#0f0'"
-      ></note-box>
-    </note-canvas>
-  </div>
+  <note-canvas id="note-canvas"
+    @canvas-click="onCanvasClick"
+    @canvas-mousedown="onCanvasMouseDown"
+    @canvas-mousedrag="onCanvasMouseDrag"
+    @canvas-mouseup="onCanvasMouseUp"
+   @canvas-mouseleave="onCanvasMouseLeave"
+  >
+    <note-box
+      v-if="newBox"
+      :x="newBox.x"
+      :y="newBox.y"
+      :width="newBox.width"
+      :height="newBox.height"
+      :color="'#afa'"
+      layer="foreground"
+    ></note-box>
+    <note-box
+      v-for="box in noteBoxes"
+      :x="box.x"
+      :y="box.y"
+      :width="box.width"
+      :height="box.height"
+      :color="'#0f0'"
+    ></note-box>
+  </note-canvas>
 </template>
 <script>
-  import {Track, NoteCanvasAdapter} from './Music.js'
+  import {Track, NoteCanvasAdapter, NoteTooSmallException} from './Music.js'
   import NoteCanvas from './NoteCanvas.vue'
   import NoteBox from './NoteBox.vue'
 
@@ -26,21 +39,56 @@
       const track = new Track(4, 1)
       return {
         track,
+        newBox: null,
         renderContext: {
           // Percentage of the canvas filled by a quarter note,
-          // i.e. 1/4th of a bar
+          // i.e. 1/4th of a bar.
           percentPerQuarter: 10,
           // Percentage of the canvas filled by a note interval,
           // i.e. the difference in pitch between A and A#
-          percentPerInterval: 25
+          percentPerInterval: 20
         }
       }
     },
     methods: {
-      onClickCanvas ({x, y}) {
-        const box = {x, y, width: 10, height: 10}
-        const note = canvasAdapter.toNote(this.renderContext, box)
-        this.track.addNote(note)
+      addNoteFromBox (box) {
+        try {
+          const note = canvasAdapter.toNote(this.renderContext, box)
+          this.track.addNote(note)
+          return note
+        } catch (e) {
+          if (e instanceof NoteTooSmallException) {
+            return
+          }
+          throw e
+        }
+      },
+      onCanvasClick ({x, y}) {
+        let box = {
+          x,
+          y,
+          width: this.renderContext.percentPerQuarter,
+          height: this.renderContext.percentPerInterval
+        }
+        box = canvasAdapter.clip(this.renderContext, box)
+        this.addNoteFromBox(box)
+      },
+      onCanvasMouseDown ({x, y}) {
+        const height = this.renderContext.percentPerInterval
+        const width = 0
+        const box = {x, y, width, height}
+        this.newBox = canvasAdapter.clip(this.renderContext, box)
+      },
+      onCanvasMouseDrag ({x}) {
+        this.newBox.width = x - this.newBox.x
+        this.newBox = canvasAdapter.clip(this.renderContext, this.newBox)
+      },
+      onCanvasMouseUp () {
+        this.addNoteFromBox(this.newBox)
+        this.newBox = null
+      },
+      onCanvasMouseLeave () {
+        this.newBox = null
       }
     },
     computed: {
@@ -53,9 +101,8 @@
   }
 </script>
 <style lang="scss" scoped>
-  .wrapper {
-    display: grid;
-    grid-template-rows: auto 1fr;
-    grid-template-columns: 1fr;
+  #note-canvas {
+    width: 100%;
+    height: 100%;
   }
 </style>

--- a/src/renderer/components/MusicTrack/NoteBox.vue
+++ b/src/renderer/components/MusicTrack/NoteBox.vue
@@ -10,7 +10,7 @@
   const percentHeightToPix = (percent, ctx) => Math.floor((ctx.canvas.height / 100) * percent)
 
   export default {
-    inject: ['provider'],
+    inject: ['layers'],
     props: {
       // Top-left corner coordinates (percentage of canvas dimensions)
       x: {
@@ -53,7 +53,7 @@
     },
     computed: {
       context () {
-        return this.provider[this.layer]
+        return this.layers[this.layer]
       },
       calculatedBox () {
         const ctx = this.context

--- a/src/renderer/components/MusicTrack/NoteCanvas.vue
+++ b/src/renderer/components/MusicTrack/NoteCanvas.vue
@@ -21,7 +21,7 @@
         dragging: false,
         clicking: false,
         canvasDimensions: null,
-        provider: {
+        layers: {
           background: null,
           foreground: null
         }
@@ -29,19 +29,18 @@
     },
     mounted () {
       // Canvas are only accessible once the component is mounted in the DOM
-      Object.keys(this.provider).forEach((layer) => this.setUpCanvas(layer))
+      Object.keys(this.layers).forEach((layer) => this.setUpCanvas(layer))
     },
     provide () {
-      // Allow child components to `inject: ['provider']`
-      // and have access to it.
+      // Allow child components to access the layers via `inject: ['layers']`.
       return {
-        provider: this.provider
+        layers: this.layers
       }
     },
     methods: {
       setUpCanvas (layer) {
         const canvas = this.$refs[layer]
-        this.provider[layer] = canvas.getContext('2d')
+        this.layers[layer] = canvas.getContext('2d')
         // Store the first layer's parent's dimensions to use the same dimensions
         // for all layers.
         if (!this.canvasDimensions) {

--- a/src/renderer/components/MusicTrack/NoteCanvas.vue
+++ b/src/renderer/components/MusicTrack/NoteCanvas.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="wrapper">
-    <canvas ref="note-canvas" @click="onClick"></canvas>
+    <canvas ref="background" class="background"></canvas>
+    <canvas ref="foreground" class="foreground"
+      @click="onClick"
+      @mousedown="onMouseDown"
+      @mouseup="onMouseUp"
+      @mousemove="onMouseMove"
+      @mouseleave="onMouseLeave"
+    ></canvas>
     <!-- Children components will be mounted here -->
     <slot></slot>
   </div>
@@ -11,21 +18,18 @@
     name: 'NoteCanvas',
     data () {
       return {
+        dragging: false,
+        clicking: false,
+        canvasDimensions: null,
         provider: {
-          context: null
+          background: null,
+          foreground: null
         }
       }
     },
-    methods: {
-      onClick (event) {
-        const canvas = this.$refs['note-canvas']
-        const canvasLeft = canvas.offsetLeft
-        const canvasTop = canvas.offsetTop
-        this.$emit('canvas-click', {
-          x: 100 * (event.pageX - canvasLeft) / canvas.width,
-          y: 100 * (event.pageY - canvasTop) / canvas.height
-        })
-      }
+    mounted () {
+      // Canvas are only accessible once the component is mounted in the DOM
+      Object.keys(this.provider).forEach((layer) => this.setUpCanvas(layer))
     },
     provide () {
       // Allow child components to `inject: ['provider']`
@@ -34,19 +38,76 @@
         provider: this.provider
       }
     },
-    mounted () {
-      // Canvas is only accessible once the component is mounted in the DOM
-      const canvas = this.$refs['note-canvas']
-      this.provider.context = canvas.getContext('2d')
-      // Resize canvas to fit its parent's width and height
-      canvas.width = canvas.parentElement.clientWidth
-      canvas.height = canvas.parentElement.clientHeight
+    methods: {
+      setUpCanvas (layer) {
+        const canvas = this.$refs[layer]
+        this.provider[layer] = canvas.getContext('2d')
+        // Store the first layer's parent's dimensions to use the same dimensions
+        // for all layers.
+        if (!this.canvasDimensions) {
+          this.canvasDimensions = {
+            width: canvas.parentElement.clientWidth,
+            height: canvas.parentElement.clientHeight
+          }
+        }
+        // Resize canvas to fit its parent's width and height
+        canvas.width = this.canvasDimensions.width
+        canvas.height = this.canvasDimensions.height
+      },
+      toCanvasPercentPosition (event) {
+        // NOTE: canvas layers should have the same size and same top-left position,
+        // so it does not matter which layer we choose here
+        const canvas = this.$refs['background']
+        const canvasLeft = canvas.parentElement.offsetLeft
+        const canvasTop = canvas.parentElement.offsetTop
+        return {
+          x: 100 * (event.pageX - canvasLeft) / canvas.width,
+          y: 100 * (event.pageY - canvasTop) / canvas.height
+        }
+      },
+      onClick (event) {
+        if (!this.clicking) {
+          return
+        }
+        this.$emit('canvas-click', this.toCanvasPercentPosition(event))
+        this.clicking = false
+      },
+      onMouseDown (event) {
+        this.clicking = true
+        this.dragging = true
+        this.$emit('canvas-mousedown', this.toCanvasPercentPosition(event))
+      },
+      onMouseMove (event) {
+        this.clicking = false
+        if (!this.dragging) {
+          return
+        }
+        this.$emit('canvas-mousedrag', this.toCanvasPercentPosition(event))
+      },
+      onMouseUp (event) {
+        this.dragging = false
+        this.$emit('canvas-mouseup', this.toCanvasPercentPosition(event))
+      },
+      onMouseLeave (event) {
+        this.dragging = false
+        this.clicking = false
+        this.$emit('canvas-mouseleave', this.toCanvasPercentPosition(event))
+      }
     }
   }
 </script>
 
 <style lang="scss" scoped>
   .wrapper {
-    background: gold;
+    position: relative;
+    .background {
+      background: gold;
+    }
+    .foreground {
+      position: absolute;
+      top: 0;
+      left: 0;
+      background: transparent;
+    }
   }
 </style>


### PR DESCRIPTION
# Suggested changes

- Undraw a note box when it is destroyed.
- When creating a note, dragging it on the canvas will change its duration.
- Use "foreground" and "background" canvas - foreground for note being created, background for notes already added.

NOTE: it is still possible to simply click on the canvas to add a note.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/15911462/50284092-38515c00-0458-11e9-99cc-4f644e45778a.gif)
