### PR TITLE
Améliorations design #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "author": "cloune <rachel@nebulae.co>",
   "description": "An electron-vue project",
-  "license": null,
   "main": "./dist/electron/main.js",
   "scripts": {
+    "start": "npm run dev",
     "build": "node .electron-vue/build.js && electron-builder",
     "build:dir": "node .electron-vue/build.js && electron-builder --dir",
     "build:clean": "cross-env BUILD_TARGET=clean node .electron-vue/build.js",

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -15,10 +15,6 @@
 
 <style lang="scss">
   @import './styles/_bootstrap_override.scss';
-  @import "../../node_modules/bootstrap/scss/bootstrap.scss";
-  @import url('https://fonts.googleapis.com/css?family=Amatic+SC');
-
-  $font-family-titles: "Amatic SC", cursive;
 
   html, body {
     width: 100vw;

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -14,10 +14,18 @@
 </script>
 
 <style lang="scss">
+  @import './styles/_bootstrap_override.scss';
   @import "../../node_modules/bootstrap/scss/bootstrap.scss";
+  @import url('https://fonts.googleapis.com/css?family=Amatic+SC');
+
+  $font-family-titles: "Amatic SC", cursive;
+
   html, body {
     width: 100vw;
     height: 100vh;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-family: $font-family-titles;
   }
   #app {
     width: 100%;

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1,12 +1,15 @@
 <template>
   <div id="app">
+    <nav-bar></nav-bar>
     <router-view></router-view>
   </div>
 </template>
 
 <script>
+  import Navbar from './components/Navbar.vue'
   export default {
-    name: 'polyphona'
+    name: 'polyphona',
+    components: { 'nav-bar': Navbar }
   }
 </script>
 

--- a/src/renderer/components/Home.vue
+++ b/src/renderer/components/Home.vue
@@ -1,12 +1,5 @@
 <template>
   <div id="home">
-    <h1>Polyphona</h1>
-    <p>
-      <router-link to="login">Login</router-link>
-    </p>
-    <p>
-      <router-link to="register">Create an account</router-link>
-    </p>
     <song-editor></song-editor>
   </div>
 </template>

--- a/src/renderer/components/Login.vue
+++ b/src/renderer/components/Login.vue
@@ -1,14 +1,9 @@
 <template>
   <div class="container" id="container">
-    <p class="text-muted">
-      <router-link to="home">Home</router-link>
-    </p>
     <h1>Sign in</h1>
     <p class="text-muted">Enter your Polyphona account details to sign in.</p>
 
-    <div class="alert alert-danger" v-if="error" role="alert">
-      {{ error }}
-    </div>
+    <div class="alert alert-danger" v-if="error" role="alert">{{ error }}</div>
 
     <form @submit.prevent="onSubmit">
       <div class="form-group">
@@ -17,7 +12,14 @@
           <div class="input-group-prepend">
             <span class="input-group-text">👤</span>
           </div>
-          <input v-model="username" id="username" type="text" class="form-control" placeholder="Username" required/>
+          <input
+            v-model="username"
+            id="username"
+            type="text"
+            class="form-control"
+            placeholder="Username"
+            required
+          >
         </div>
       </div>
 
@@ -27,7 +29,14 @@
           <div class="input-group-prepend">
             <span class="input-group-text">🔒</span>
           </div>
-          <input v-model="password" id="password" type="password" class="form-control" placeholder="Password" required/>
+          <input
+            v-model="password"
+            id="password"
+            type="password"
+            class="form-control"
+            placeholder="Password"
+            required
+          >
         </div>
       </div>
 
@@ -64,9 +73,7 @@
 </script>
 
 <style scoped>
-  #container {
-    width: 30em;
-    margin-top: 3em;
-  }
-
+#container {
+  width: 30em;
+}
 </style>

--- a/src/renderer/components/Navbar.vue
+++ b/src/renderer/components/Navbar.vue
@@ -1,0 +1,41 @@
+<template>
+  <nav>
+    <h1 id="brand">
+      <router-link class="btn" to="/">Polyphona</router-link>
+    </h1>
+    <ul>
+      <li>
+        <router-link class="btn" to="login">Sign in</router-link>
+      </li>
+      <li>
+        <router-link class="btn btn-primary" to="register">Sign up</router-link>
+      </li>
+    </ul>
+  </nav>
+</template>
+
+<script>
+export default {
+  name: 'nav-bar'
+}
+</script>
+
+<style lang="scss" scoped>
+nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: .5em 1em;
+  #brand {
+    font-size: 1em;
+    margin: 0;
+    padding: 0;
+  }
+  ul {
+    display: flex;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+}
+</style>

--- a/src/renderer/components/Navbar.vue
+++ b/src/renderer/components/Navbar.vue
@@ -1,7 +1,7 @@
 <template>
   <nav>
     <h1 id="brand">
-      <router-link class="btn" to="/">Polyphona</router-link>
+      <router-link to="/">♫ Polyphona</router-link>
     </h1>
     <ul>
       <li>
@@ -27,7 +27,6 @@ nav {
   align-items: center;
   padding: .5em 1em;
   #brand {
-    font-size: 1em;
     margin: 0;
     padding: 0;
   }

--- a/src/renderer/components/Register.vue
+++ b/src/renderer/components/Register.vue
@@ -1,14 +1,9 @@
 <template>
   <div class="container" id="container">
-    <p class="text-muted">
-      <router-link to="home">Home</router-link>
-    </p>
     <h1>Create an account</h1>
     <p class="text-muted">Enter your account details.</p>
 
-    <div class="alert alert-danger" role="alert" v-if="error">
-      {{ error }}
-    </div>
+    <div class="alert alert-danger" role="alert" v-if="error">{{ error }}</div>
 
     <form @submit.prevent="onSubmit">
       <div class="form-group">
@@ -17,24 +12,42 @@
           <div class="input-group-prepend">
             <span class="input-group-text">👤</span>
           </div>
-          <input v-model="username" id="username" type="text" class="form-control" placeholder="Enter username…"
-                 required/>
+          <input
+            v-model="username"
+            id="username"
+            type="text"
+            class="form-control"
+            placeholder="Enter username…"
+            required
+          >
         </div>
       </div>
 
       <div class="form-group">
         <label for="first-name">First name</label>
         <div class="input-group">
-          <input v-model="firstName" id="first-name" type="text" class="form-control"
-                 placeholder="Enter your first name…" required/>
+          <input
+            v-model="firstName"
+            id="first-name"
+            type="text"
+            class="form-control"
+            placeholder="Enter your first name…"
+            required
+          >
         </div>
       </div>
 
       <div class="form-group">
         <label for="last-name">Last name</label>
         <div class="input-group">
-          <input v-model="lastName" id="last-name" type="text" class="form-control" placeholder="Enter your last name…"
-                 required/>
+          <input
+            v-model="lastName"
+            id="last-name"
+            type="text"
+            class="form-control"
+            placeholder="Enter your last name…"
+            required
+          >
         </div>
       </div>
 
@@ -44,8 +57,14 @@
           <div class="input-group-prepend">
             <span class="input-group-text">🔒</span>
           </div>
-          <input v-model="password" id="password" type="password" class="form-control" placeholder="Enter password…"
-                 required/>
+          <input
+            v-model="password"
+            id="password"
+            type="password"
+            class="form-control"
+            placeholder="Enter password…"
+            required
+          >
         </div>
       </div>
 
@@ -54,8 +73,14 @@
           <div class="input-group-prepend">
             <span class="input-group-text">🔒</span>
           </div>
-          <input v-model="passwordConfirm" id="password_conformity" type="password" class="form-control"
-                 placeholder="Confirm password…" required/>
+          <input
+            v-model="passwordConfirm"
+            id="password_conformity"
+            type="password"
+            class="form-control"
+            placeholder="Confirm password…"
+            required
+          >
         </div>
       </div>
 
@@ -105,9 +130,7 @@
 </script>
 
 <style scoped>
-  #container {
-    width: 30em;
-    margin-top: 3em;
-  }
-
+#container {
+  width: 30em;
+}
 </style>

--- a/src/renderer/components/SongEditor/CanvasDelimiter.vue
+++ b/src/renderer/components/SongEditor/CanvasDelimiter.vue
@@ -22,24 +22,12 @@
         type: Number,
         default: 1
       },
-      // Color of the box
       color: {
         type: String,
         default: '#ddd'
       },
       layer: {
         type: String
-      }
-    },
-    data () {
-      return {
-        height: 100 // canvas percent
-      }
-    },
-    methods: {
-      clear (ctx) {
-        const {x, top, bottom} = this.line
-        ctx.clearRect(x, top, 1, bottom - top)
       }
     },
     computed: {
@@ -70,16 +58,13 @@
       const {start, end} = this.line
 
       ctx.beginPath()
+      ctx.save()
       ctx.moveTo(start.x, start.y)
       ctx.lineTo(end.x, end.y)
       ctx.strokeStyle = this.color
       ctx.lineWidth = this.width
       ctx.stroke()
-    },
-    destroyed () {
-      // Undraw from canvas
-      const ctx = this.context
-      this.clear(ctx)
+      ctx.restore()
     }
   }
 </script>

--- a/src/renderer/components/SongEditor/CanvasDelimiter.vue
+++ b/src/renderer/components/SongEditor/CanvasDelimiter.vue
@@ -1,0 +1,85 @@
+<script>
+  /* NOTE: this is a JS-only component. */
+  import { percentWidthToPix, percentHeightToPix } from './utils'
+
+  export default {
+    inject: ['layers'],
+    props: {
+      // X coordinate (percentage of canvas dimensions)
+      x: {
+        type: Number,
+        default: 0
+      },
+      y: {
+        type: Number,
+        default: 0
+      },
+      vertical: {
+        type: Boolean,
+        default: true
+      },
+      width: {
+        type: Number,
+        default: 1
+      },
+      // Color of the box
+      color: {
+        type: String,
+        default: '#ddd'
+      },
+      layer: {
+        type: String
+      }
+    },
+    data () {
+      return {
+        height: 100 // canvas percent
+      }
+    },
+    methods: {
+      clear (ctx) {
+        const {x, top, bottom} = this.line
+        ctx.clearRect(x, top, 1, bottom - top)
+      }
+    },
+    computed: {
+      context () {
+        return this.layers[this.layer]
+      },
+      line () {
+        return {
+          start: {
+            x: percentWidthToPix(this.vertical ? this.x : 0, this.context),
+            y: percentHeightToPix(this.vertical ? 0 : this.y, this.context)
+          },
+          end: {
+            x: percentWidthToPix(this.vertical ? this.x : 100, this.context),
+            y: percentHeightToPix(this.vertical ? 100 : this.y, this.context)
+          }
+        }
+      }
+    },
+    render () {
+      const ctx = this.context
+
+      // It is *possible* that the canvas context may not be injected yet.
+      if (!ctx) {
+        return
+      }
+
+      const {start, end} = this.line
+
+      ctx.beginPath()
+      ctx.moveTo(start.x, start.y)
+      ctx.lineTo(end.x, end.y)
+      ctx.strokeStyle = this.color
+      ctx.lineWidth = this.width
+      ctx.stroke()
+    },
+    destroyed () {
+      // Undraw from canvas
+      const ctx = this.context
+      this.clear(ctx)
+    }
+  }
+</script>

--- a/src/renderer/components/SongEditor/CanvasLine.vue
+++ b/src/renderer/components/SongEditor/CanvasLine.vue
@@ -5,7 +5,6 @@
   export default {
     inject: ['layers'],
     props: {
-      // X coordinate (percentage of canvas dimensions)
       x: {
         type: Number,
         default: 0
@@ -30,21 +29,44 @@
         type: String
       }
     },
+    data () {
+      return {
+        box: null
+      }
+    },
     computed: {
       context () {
         return this.layers[this.layer]
       },
       line () {
-        return {
+        const ctx = this.context
+        const line = {
           start: {
-            x: percentWidthToPix(this.vertical ? this.x : 0, this.context),
-            y: percentHeightToPix(this.vertical ? 0 : this.y, this.context)
+            x: percentWidthToPix(this.vertical ? this.x : 0, ctx),
+            y: percentHeightToPix(this.vertical ? 0 : this.y, ctx)
           },
           end: {
-            x: percentWidthToPix(this.vertical ? this.x : 100, this.context),
-            y: percentHeightToPix(this.vertical ? 100 : this.y, this.context)
+            x: percentWidthToPix(this.vertical ? this.x : 100, ctx),
+            y: percentHeightToPix(this.vertical ? 100 : this.y, ctx)
           }
         }
+        // NOTE: this only works for vertical lines.
+        this.box = {
+          x: line.start.x - this.width,
+          y: line.start.y,
+          width: 2 * this.width,
+          height: line.end.y - line.start.y
+        }
+        return line
+      }
+    },
+    methods: {
+      clear (ctx) {
+        const box = this.box
+        if (!box) {
+          return
+        }
+        ctx.clearRect(box.x, box.y, box.width, box.height)
       }
     },
     render () {
@@ -55,6 +77,7 @@
         return
       }
 
+      this.clear(ctx)
       const {start, end} = this.line
 
       ctx.beginPath()
@@ -65,6 +88,9 @@
       ctx.lineWidth = this.width
       ctx.stroke()
       ctx.restore()
+    },
+    destroyed () {
+      this.clear(this.context)
     }
   }
 </script>

--- a/src/renderer/components/SongEditor/NoteBox.vue
+++ b/src/renderer/components/SongEditor/NoteBox.vue
@@ -5,9 +5,7 @@
   Instead, it provides a render() function directly which draws the note box to the canvas.
    */
 
-  // Helper functions to convert a percentage of canvas area to pixels.
-  const percentWidthToPix = (percent, ctx) => Math.floor((ctx.canvas.width / 100) * percent)
-  const percentHeightToPix = (percent, ctx) => Math.floor((ctx.canvas.height / 100) * percent)
+  import {percentWidthToPix, percentHeightToPix} from './utils'
 
   export default {
     inject: ['layers'],
@@ -33,7 +31,7 @@
       // Color of the box
       color: {
         type: String,
-        default: '#f00'
+        default: '#f6cd4c'
       },
       layer: {
         type: String,
@@ -42,7 +40,7 @@
     },
     data () {
       return {
-        strokeWidth: 10,
+        strokeWidth: 1,
         oldBox: {
           x: 0,
           y: 0,
@@ -105,6 +103,7 @@
       ctx.clip()
       ctx.fillStyle = this.color
       ctx.lineWidth = this.strokeWidth
+      ctx.strokeStyle = '#999'
       ctx.fill()
       ctx.stroke()
       ctx.restore()

--- a/src/renderer/components/SongEditor/NoteCanvas.vue
+++ b/src/renderer/components/SongEditor/NoteCanvas.vue
@@ -130,7 +130,7 @@
         return Object.keys(SCALE).map((index) => ({
           id: index,
           name: SCALE[index]
-        }))
+        })).reverse()
       }
     },
     methods: {

--- a/src/renderer/components/SongEditor/NoteCanvas.vue
+++ b/src/renderer/components/SongEditor/NoteCanvas.vue
@@ -241,8 +241,10 @@
         this.newBox = canvasAdapter.clip(this.renderContext, this.newBox)
       },
       onMouseUp (event) {
+        if (this.dragging) {
+          this.addNoteFromBox(this.newBox)
+        }
         this.dragging = false
-        this.addNoteFromBox(this.newBox)
         this.newBox = null
       },
       onMouseLeave (event) {

--- a/src/renderer/components/SongEditor/NoteCanvas.vue
+++ b/src/renderer/components/SongEditor/NoteCanvas.vue
@@ -1,49 +1,62 @@
 <template>
   <div class="wrapper">
-    <canvas ref="background" class="background"></canvas>
-    <canvas ref="notes" class="layer"></canvas>
-    <canvas-delimiter
-      v-for="delimiter in delimiters"
-      :x="delimiter.x"
-      :y="delimiter.y"
-      :vertical="delimiter.vertical"
-      :width="delimiter.width"
-      :key="'delimiter-' + delimiter.id"
-      layer="background"
-    ></canvas-delimiter>
-    <canvas
-      ref="foreground"
-      class="layer"
-      @click="onClick"
-      @mousedown="onMouseDown"
-      @mouseup="onMouseUp"
-      @mousemove="onMouseMove"
-      @mouseleave="onMouseLeave"
-    ></canvas>
-    <note-box
-      v-if="newBox"
-      :x="newBox.x"
-      :y="newBox.y"
-      :width="newBox.width"
-      :height="newBox.height"
-      :color="'#ffe17f'"
-      layer="foreground"
-    ></note-box>
-    <note-box
-      v-for="box in noteBoxes"
-      :key="'note-' + box.id"
-      :x="box.x"
-      :y="box.y"
-      :width="box.width"
-      :height="box.height"
-      :color="'#f6cd4c'"
-      layer="notes"
-    ></note-box>
+    <!-- Show the names of the notes in a column. -->
+    <ol id="note-pitches">
+      <li v-for="pitch in pitches" :key="'pitch-' + pitch.id">{{ pitch.name }}</li>
+    </ol>
+    <div class="canvas-wrapper">
+      <!-- Canvas layers. -->
+      <canvas ref="background" class="background"></canvas>
+      <canvas ref="notes" class="layer"></canvas>
+      <canvas
+        ref="foreground"
+        class="layer"
+        @click="onClick"
+        @mousedown="onMouseDown"
+        @mouseup="onMouseUp"
+        @mousemove="onMouseMove"
+        @mouseleave="onMouseLeave"
+      ></canvas>
+
+      <!-- Delimiters of notes on the canvas -->
+      <canvas-delimiter
+        v-for="delimiter in delimiters"
+        :x="delimiter.x"
+        :y="delimiter.y"
+        :vertical="delimiter.vertical"
+        :width="delimiter.width"
+        :key="'delimiter-' + delimiter.id"
+        layer="background"
+      ></canvas-delimiter>
+
+      <!-- Note being created (if any) -->
+      <note-box
+        v-if="newBox"
+        :x="newBox.x"
+        :y="newBox.y"
+        :width="newBox.width"
+        :height="newBox.height"
+        :color="'#ffe17f'"
+        layer="foreground"
+      ></note-box>
+
+      <!-- Notes in the song. -->
+      <note-box
+        v-for="box in noteBoxes"
+        :key="'note-' + box.id"
+        :x="box.x"
+        :y="box.y"
+        :width="box.width"
+        :height="box.height"
+        :color="'#f6cd4c'"
+        layer="notes"
+      ></note-box>
+    </div>
   </div>
 </template>
 
 <script>
-  import {NoteCanvasAdapter, NoteTooSmallException} from '@/store/Music'
+  import {NoteCanvasAdapter, SCALE, NoteTooSmallException} from '@/store/Music'
   import NoteBox from './NoteBox'
   import CanvasDelimiter from './CanvasDelimiter.vue'
 
@@ -112,6 +125,12 @@
           this.delimiterId++
         }
         return [...horizontalDelimiters, ...verticalDelimiters]
+      },
+      pitches () {
+        return Object.keys(SCALE).map((index) => ({
+          id: index,
+          name: SCALE[index]
+        }))
       }
     },
     methods: {
@@ -205,7 +224,27 @@
 <style lang="scss" scoped>
   @import "../../styles/_bootstrap_override.scss";
   .wrapper {
+    // position: relative;
+    display: flex;
+  }
+  #note-pitches {
+    display: flex;
+    flex-flow: column;
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+    text-align: center;
+    color: map-get($theme-colors, "light");
+    background: map-get($theme-colors, "dark");
+    li {
+      padding: 0 .5em;
+      margin: auto 0;
+    }
+  }
+  .canvas-wrapper {
     position: relative;
+    height: 100%;
+    flex: 1;
 
     .background {
       background: map-get($theme-colors, "light");

--- a/src/renderer/components/SongEditor/SongEditor.vue
+++ b/src/renderer/components/SongEditor/SongEditor.vue
@@ -1,21 +1,22 @@
 <template>
   <div id="song-editor">
-    <p style="display: flex;">
+    <form id="song-tools">
       <span class="form-field">
-        <button @click="togglePlay">{{ playing ? '❙❙' : '►️'}}️</button>
+        <button class="btn btn-light" @click="togglePlay" type="button">{{ playing ? '❙❙' : '►️'}}️</button>
       </span>
-      <span class="form-field">
+      <span class="form-group">
         <label for="octave">Octave:</label>
-        <select id="octave" v-model="octave">
-          <option :value="1">1</option>
-          <option :value="2">2</option>
-          <option :value="3">3</option>
-          <option :value="4">4</option>
-          <option :value="5">5</option>
-          <option :value="6">6</option>
-        </select>
+        <input
+          id="octave"
+          class="form-control"
+          type="number"
+          min="1"
+          max="6"
+          required
+          v-model="octave"
+        >
       </span>
-    </p>
+    </form>
     <note-canvas id="note-canvas"></note-canvas>
   </div>
 </template>
@@ -50,12 +51,15 @@
     height: 70%;
   }
 
+  #song-tools {
+    padding: 1em;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
   #note-canvas {
     width: 100%;
     height: 100%;
-  }
-
-  .form-field {
-    margin: 1em;
   }
 </style>

--- a/src/renderer/components/SongEditor/utils.js
+++ b/src/renderer/components/SongEditor/utils.js
@@ -1,0 +1,9 @@
+// Helper functions to convert a percentage of canvas area to pixels.
+
+export function percentWidthToPix (percent, ctx) {
+  return Math.floor((ctx.canvas.width / 100) * percent)
+}
+
+export function percentHeightToPix (percent, ctx) {
+  return Math.floor((ctx.canvas.height / 100) * percent)
+}

--- a/src/renderer/store/Music.js
+++ b/src/renderer/store/Music.js
@@ -27,12 +27,13 @@ export class Note {
 
 export class NoteCanvasAdapter {
   toBox (renderContext, note) {
+    const height = renderContext.percentPerInterval
     return {
       id: note.id,
       x: renderContext.percentPerTick * note.startTime,
-      y: renderContext.percentPerInterval * note.pitch,
+      y: 100 - (height + renderContext.percentPerInterval * note.pitch),
       width: renderContext.percentPerTick * note.duration,
-      height: renderContext.percentPerInterval
+      height
     }
   }
 
@@ -44,7 +45,7 @@ export class NoteCanvasAdapter {
     return new Note(
       Math.floor(box.x / renderContext.percentPerTick),
       duration,
-      Math.floor(box.y / renderContext.percentPerInterval)
+      Math.floor((100 - (box.y + box.height)) / renderContext.percentPerInterval)
     )
   }
 

--- a/src/renderer/store/modules/MusicStore.js
+++ b/src/renderer/store/modules/MusicStore.js
@@ -81,24 +81,27 @@ const actions = {
     context.commit('DELETE_NOTE', note)
     context.dispatch('restart')
   },
-  play (context, offset) {
-    context.commit('SCHEDULE_NOTES')
+  play ({commit}, offset) {
+    commit('SCHEDULE_NOTES')
     // Loop one measure ad eternam
     Tone.Transport.loopEnd = '1m'
     Tone.Transport.loop = true
     // Start the song now, but offset by `offset`.
     Tone.Transport.start(Tone.Transport.now(), offset)
   },
+  stop () {
+    Tone.Transport.stop()
+  },
   restart (context) {
     if (context.state.musicContext.playing) {
       const offset = Tone.Transport.getSecondsAtTime()
-      Tone.Transport.stop()
+      context.dispatch('stop')
       context.dispatch('play', offset)
     }
   },
   togglePlay (context) {
     if (context.state.musicContext.playing) {
-      Tone.Transport.stop()
+      context.dispatch('stop')
     } else {
       context.dispatch('play')
     }

--- a/src/renderer/store/modules/MusicStore.js
+++ b/src/renderer/store/modules/MusicStore.js
@@ -14,7 +14,7 @@ const state = {
   musicContext: {
     division,
     scale,
-    octave: 4,
+    octave: 2,
     playing: false
   },
   // Mapping of note IDs to transport event IDs.

--- a/src/renderer/styles/_bootstrap_override.scss
+++ b/src/renderer/styles/_bootstrap_override.scss
@@ -1,0 +1,12 @@
+// See: https://getbootstrap.com/docs/4.2/getting-started/theming/
+@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro');
+
+$theme-colors: (
+    "primary": #34c997,
+    "secondary": #455a64,
+    "warning": #f6cd4c,
+);
+
+$body-bg: white;
+$body-color: #555;
+$font-family-sans-serif: "Source Code Pro", -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";

--- a/src/renderer/styles/_bootstrap_override.scss
+++ b/src/renderer/styles/_bootstrap_override.scss
@@ -1,5 +1,6 @@
 // See: https://getbootstrap.com/docs/4.2/getting-started/theming/
 @import url('https://fonts.googleapis.com/css?family=Source+Code+Pro');
+@import url('https://fonts.googleapis.com/css?family=Amatic+SC');
 
 $theme-colors: (
     "primary": #34c997,
@@ -10,3 +11,7 @@ $theme-colors: (
 $body-bg: white;
 $body-color: #555;
 $font-family-sans-serif: "Source Code Pro", -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+@import "../../../node_modules/bootstrap/scss/bootstrap.scss";
+
+$font-family-titles: "Amatic SC", cursive;


### PR DESCRIPTION
Changements : 

- Ajout d'une navbar avec la brand (qui permet de retourner à l'accueil) et les boutons login/sign up.
- Elle s'affiche sur toutes les vues de l'app, y compris les pages login et sign up.
- Personnalisation de la police et des couleurs (inspiré de la slide projet Polyphona).

![screenshot 2019-02-07 at 20 34 58](https://user-images.githubusercontent.com/15911462/52437755-f79cc780-2b17-11e9-8412-0e844cb2c4ec.png)

- Amélioration de l'esthétique du canvas
- Affichage du nom des notes en début de piste (grave en bas, aigu en haut, avec correction associées au niveau du `NoteCanvasAdapter`)
- Amélioration des dimensions de la note en train d'être créée lorsqu'on la drag : c'est maintenant bcp plus intuitif :)
- Ajout d'une barre de progression :tada:

![screenshot 2019-02-08 at 17 45 35](https://user-images.githubusercontent.com/15911462/52492504-a1885c80-2bc9-11e9-8817-a4ac487952af.png)

RQ : il y a un problème de matching entre la hauteur de la colonne des notes et le canvas, dû au fait que le canvas ne se resize pas avec la fenêtre.